### PR TITLE
add inline svg tags to isHtml tag.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export function isNumber(text: string): boolean {
 }
 /** Check whether text starts with an html tag. */
 export function isHtmlTag(text: string) {
-  return /^[\t ]*(a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|menu|menuitem|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|path)((:|::|,|\.|#|\[)[:$#{}()\w\-\[\]='",\.# +]*)?$/.test(
+  return /^[\t ]*(a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|keygen|label|legend|li|link|main|map|mark|menu|menuitem|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|pre|progress|q|rb|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|path|circle|ellipse|line|polygon|polyline|rect|text)((:|::|,|\.|#|\[)[:$#{}()\w\-\[\]='",\.# +]*)?$/.test(
     text
   );
 }


### PR DESCRIPTION
Solving the sass format problem in the vscode-sass-indented extension

```sass
svg
    transform: translate(15px, -15px)
    circle
        fill-opacity: 0
        &:hover
            fill-opacity: 0.04
        &:active
            fill-opacity: 0.23
```
after formatting
```sass
svg
    transform: translate(15px, -15px)
    circle
    fill-opacity: 0
    &:hover
        fill-opacity: 0.04
        &:active
            fill-opacity: 0.23
```